### PR TITLE
Add EAC helper functions

### DIFF
--- a/helpers/lookup.inc.php
+++ b/helpers/lookup.inc.php
@@ -82,3 +82,47 @@ function cacheAccessionIdentifierIds()
 
     return $ids;
 }
+
+function getTermIdUsingName($name)
+{
+  $sql = 'SELECT id FROM term_i18n WHERE name=? AND culture=?';
+
+  return QubitPdo::fetchColumn($sql, [$name, 'en']);
+}
+
+function getTermIdFromTaxonomyUsingName($name, $taxonomyId)
+{
+  $sql = 'SELECT ti.id FROM term_i18n ti JOIN term t ON t.id = ti.id WHERE ti.name=? AND ti.culture=? AND t.taxonomy_id=?';
+
+  return QubitPdo::fetchColumn($sql, [$name, 'en', $taxonomyId]);
+}
+
+function getTermIdFromCachedTermsByName($name, $termCache)
+{
+  return array_search($name, $termCache);
+}
+
+function cacheTerms($taxonomyId)
+{
+  $terms = [];
+
+  $sql = 'SELECT ti.id, ti.name FROM term_i18n ti JOIN term t ON t.id = ti.id WHERE ti.culture=? AND t.taxonomy_id=?';
+
+  foreach (QubitPdo::fetchAll($sql, ['en', $taxonomyId], array('fetchMode' => PDO::FETCH_ASSOC)) as $result) {
+        $name = $result['name'];
+        $id = $result['id'];
+        $terms[$id] = $name;
+    }
+
+    return $terms;
+}
+
+function cacheSubjectTerms()
+{
+    return cacheTerms(QubitTaxonomy::SUBJECT_ID);
+}
+
+function cachePlaceTerms()
+{
+    return cacheTerms(QubitTaxonomy::PLACE_ID);
+}

--- a/helpers/premis.inc.php
+++ b/helpers/premis.inc.php
@@ -59,15 +59,10 @@ function addOrGetRights($objectId, $basisId = null)
   $criteria = new Criteria;
   $criteria->add(QubitRelation::SUBJECT_ID, $objectId);
   $criteria->add(QubitRelation::TYPE_ID, QubitTerm::RIGHT_ID);
-  if (null !== $relation = QubitRelation::getOne($criteria))
+  $criteria->addJoin(QubitRelation::OBJECT_ID, QubitRights::ID);
+  if (null !== $rights = QubitRights::getOne($criteria))
   {
-    $rightsId = $relation->objectId;
-    $criteria = new Criteria;
-    $criteria->add(QubitRights::ID, $rightsId);
-    if (null !== $rights = QubitRights::getOne($criteria))
-    {
-      return $rights;
-    }
+    return $rights;
   }
 
   if (empty($basisId))

--- a/helpers/premis.inc.php
+++ b/helpers/premis.inc.php
@@ -14,18 +14,29 @@ function getStatueCitationId()
     return $id;
 }
 
+function getActId($nameText='Disseminate')
+{
+  $sql = "SELECT id from term_i18n WHERE name=? AND culture='en'";
+
+  $id = QubitPdo::fetchColumn($sql, [$nameText]);
+
+  if ($id === false)
+  {
+    print "Act ". $nameText ." does not exist in AtoM database.\n";
+    exit;
+  }
+
+  return $id;
+}
+
+function getDisplayActId()
+{
+    return getActId('Display');
+}
+
 function getDisseminateActId()
 {
-    $sql = "SELECT id from term_i18n WHERE name=? AND culture='en'";
-
-    $id = QubitPdo::fetchColumn($sql, ["Disseminate"]);
-
-    if ($id === false) {
-        print "Run this after create_container_note_type_and_premis_statute.php\n";
-        exit;
-    }
-
-    return $id;
+    return getActId('Disseminate');
 }
 
 function getUnderCopyrightId()
@@ -42,32 +53,59 @@ function getUnderCopyrightId()
     return $id;
 }
 
-function addRights($objectId, $copyrightStatusId, $citationId, $actId, $restriction, $basisId = null)
+function addOrGetRights($objectId, $basisId = null)
 {
-    if (empty($basisId)) {
-        $basisId = QubitTerm::RIGHT_BASIS_POLICY_ID;
+  // Return existing rights if already linked to object
+  $criteria = new Criteria;
+  $criteria->add(QubitRelation::SUBJECT_ID, $objectId);
+  $criteria->add(QubitRelation::TYPE_ID, QubitTerm::RIGHT_ID);
+  if (null !== $relation = QubitRelation::getOne($criteria))
+  {
+    $rightsId = $relation->objectId;
+    $criteria = new Criteria;
+    $criteria->add(QubitRights::ID, $rightsId);
+    if (null !== $rights = QubitRights::getOne($criteria))
+    {
+      return $rights;
     }
+  }
 
-    $rights = new QubitRights();
-    $rights->objectId = $objectId;
-    $rights->basisId = $basisId;
-    $rights->copyrightStatusId = $copyrightStatusId;
+  if (empty($basisId))
+  {
+    $basisId = QubitTerm::RIGHT_BASIS_POLICY_ID;
+  }
 
-    if ($basisId == QubitTerm::RIGHT_BASIS_STATUTE_ID) {
-        $rights->statuteCitationId = $citationId;
-    }
+  $rights = new QubitRights;
+  $rights->objectId = $objectId;
+  $rights->basisId = $basisId;
+  $rights->save();
 
-    $rights->save();
+  $rel = new QubitRelation;
+  $rel->subjectId = $objectId;
+  $rel->objectId = $rights->id;
+  $rel->typeId = QubitTerm::RIGHT_ID;
+  $rel->save();
 
-    $granted = new QubitGrantedRight();
-    $granted->rightsId = $rights->id;
-    $granted->actId = $actId;
-    $granted->restriction = $restriction;
-    $granted->save();
+  return $rights;
+}
 
-    $rel = new QubitRelation();
-    $rel->subjectId = $objectId;
-    $rel->objectId = $rights->id;
-    $rel->typeId = QubitTerm::RIGHT_ID;
-    $rel->save();
+function addRightsNotes($rights, $rightsNote, $copyrightNote)
+{
+  $rights->rightsNote = $rightsNote;
+  $rights->copyrightNote = $copyrightNote;
+  $rights->save();
+}
+
+function addGrantedRight($rights, $actId, $restriction, $endDate, $note)
+{
+  $granted = new QubitGrantedRight;
+  $granted->rightsId = $rights->id;
+  $granted->actId = $actId;
+  $granted->restriction = $restriction;
+  $granted->endDate = $endDate;
+  $granted->note = $note;
+  $granted->save();
+
+  $rights->grantedRights[] = $granted;
+  $rights->save();
 }

--- a/helpers/terms.inc.php
+++ b/helpers/terms.inc.php
@@ -1,0 +1,122 @@
+<?php
+
+require_once(realpath(dirname(__FILE__)) .'/lookup.inc.php');
+
+function addTerm($name, $taxonomyId, $parentId, $sourceNote='', $useForTerms='', $scopeNotes='')
+{
+  // If term with this name already exists, don't add a new one.
+  $criteria = new Criteria;
+  $criteria->addJoin(QubitTerm::ID, QubitTermI18n::ID, Criteria::INNER_JOIN);
+  $criteria->add(QubitTerm::TAXONOMY_ID, $taxonomyId);
+  $criteria->add(QubitTermI18n::NAME, $name);
+
+  if (null === $term = QubitTerm::getOne($criteria))
+  {
+    // Create term
+    $term = new QubitTerm;
+    $term->taxonomyId = $taxonomyId;
+    $term->parentId = $parentId;
+    $term->name = $name;
+    $term->save();
+
+    // Deal with source note
+    if (!empty($sourceNote))
+    {
+      $note = new QubitNote();
+      $note->objectId = $term->id;
+      $note->typeId = QubitTerm::SOURCE_NOTE_ID;
+      $note->content = $sourceNote;
+      $note->culture = 'en';
+      $note->save();
+    }
+  } else {
+     print "Term with name ". $name ." already exists with ID ". $term->getId() .". Adding relationships to existing term.\n";
+  }
+
+  // Deal with use fors
+  if (!empty($useForTerms))
+  {
+    $useForTermsArray = explode('|', $useForTerms);
+    foreach($useForTermsArray as $useForTerm)
+    {
+      if (!empty($useForTerm))
+      {
+        $usedFor = new QubitOtherName();
+        $usedFor->name = $usedForTerm;
+        $usedFor->objectId = $term->id;
+        $usedFor->typeId = QubitTerm::ALTERNATIVE_LABEL_ID;
+        $usedFor->sourceCulture = 'en';
+        
+        $term->otherNames[] = $usedFor;
+      }
+    }
+  }
+
+  // Deal with scope notes
+  if (!empty($scopeNotes))
+  {
+    $scopeNotesArray = explode('|', $scopeNotes);
+    foreach($scopeNotesArray as $scopeNote)
+    {
+      if (!empty($scopeNote))
+      {
+        $note = new QubitNote();
+        $note->objectId = $term->id;
+        $note->typeId = QubitTerm::SCOPE_NOTE_ID;
+        $note->content = $scopeNote;
+        $note->culture = 'en';
+        $note->save();
+      }
+    }
+  }
+
+  echo('.');
+}
+
+function addPlaceTerm($name, $parentId, $sourceNote='', $useForTerms='', $scopeNotes='')
+{
+  addTerm($name, QubitTaxonomy::PLACE_ID, $parentId, $sourceNote, $useForTerms, $scopeNotes);
+}
+
+function addSubjectTerm($name, $parentId, $sourceNote='', $useForTerms='', $scopeNotes='')
+{
+  addTerm($name, QubitTaxonomy::SUBJECT_ID, $parentId, $sourceNote, $useForTerms, $scopeNotes);
+}
+
+function addOtherFormOfNameToTerm($term, $otherFormOfName)
+{
+  $usedFor = new QubitOtherName();
+  $usedFor->name = $otherFormOfName;
+  $usedFor->objectId = $term->id;
+  $usedFor->typeId = QubitTerm::ALTERNATIVE_LABEL_ID;
+  $usedFor->sourceCulture = 'en';
+  
+  $term->otherNames[] = $usedFor;
+}
+
+function relateTerms($objectTerm, $cachedTerms, $relatedTerms = [])
+{
+  // Add related terms
+  if (!empty($relatedTerms))
+  {
+    foreach($relatedTerms as $relatedTermName)
+    {
+      try {
+        $termName = trim($relatedTermName);
+        $relatedTermId = getTermIdFromCachedTermsByName($termName, $cachedTerms);
+        if (!empty($relatedTermId))
+        {
+          $relation = new QubitRelation;
+          $relation->objectId = $objectTerm->id;
+          $relation->subjectId = $relatedTermId;
+          $relation->typeId = QubitTerm::TERM_RELATION_ASSOCIATIVE_ID;
+          $relation->sourceCulture = 'en';
+          $relation->save();
+        }  
+      }
+      catch (exception $e) {
+         print "Error adding related term: ". $e->getMessage() ." (". $relatedTermName .")\n";
+      }
+    }
+  }
+}


### PR DESCRIPTION
This pull request introduces helpers developed during the EAC migration project. Mostly these are new helpers, but it also tweaks the existing `addRights` PREMIS helper to 1) first check to see if rights already exist for a description and if so, return that instead, and 2) move the addition of notes and granted rights to separate helper functions.